### PR TITLE
🛠️ fix: google go code style compilance (New instead of NewYFS)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,9 +62,9 @@ func main() {
 			flag.Usage()
 			os.Exit(1)
 		}
-		fs, err = yfs.NewYFS(*directory)
+		fs, err = yfs.New(*directory)
 	} else if *indexFile != "" && *freeFile != "" && *blocksFile != "" {
-		fs, err = yfs.NewYFSFromPaths(*indexFile, *freeFile, *blocksFile)
+		fs, err = yfs.NewFromPaths(*indexFile, *freeFile, *blocksFile)
 	} else {
 		fmt.Fprintf(os.Stderr, "Error: Must specify either -dir or all three files (-index, -free, -blocks)\n")
 		flag.Usage()

--- a/yfs.go
+++ b/yfs.go
@@ -53,17 +53,17 @@ type FileInfo struct {
 	BlockCount  uint32
 }
 
-// NewYFS creates a new YFS instance from a directory
-func NewYFS(dir string) (*YFS, error) {
-	return NewYFSFromPaths(
+// New creates a new YFS instance from a directory
+func New(dir string) (*YFS, error) {
+	return NewFromPaths(
 		filepath.Join(dir, "root.yfs"),
 		filepath.Join(dir, "bitmap.yfs"),
 		filepath.Join(dir, "blocks.glob"),
 	)
 }
 
-// NewYFSFromPaths creates a new YFS instance from individual file paths
-func NewYFSFromPaths(rootPath, bitmapPath, blocksPath string) (*YFS, error) {
+// NewFromPaths creates a new YFS instance from individual file paths
+func NewFromPaths(rootPath, bitmapPath, blocksPath string) (*YFS, error) {
 	yfs := &YFS{
 		rootPath:        rootPath,
 		bitmapPath:      bitmapPath,


### PR DESCRIPTION
I mentioned this change in the last PR but forgot to include it in the commit.
This PR renames the function NewYFS to New to better follow Go naming conventions, especially when the package name provides sufficient context. Sowwy
